### PR TITLE
bump go version from 1.21 to 1.22

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  go_version: 1.21
+  go_version: 1.22
 
 jobs:
   release:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ on:
       - "!dependabot/**"
 
 env:
-  go_version: '1.21'
+  go_version: '1.22'
   artifact_name: kubernetes-namespace-permission-manager
   artifact_bin_name: kubebuilder
   IMG: tagesspiegel/kubernetes-namespace-permission-manager:dev

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.


### PR DESCRIPTION
# Description

#62 fails because of vetting
> Error: Process completed with exit code 1.
> go: k8s.io/apimachinery@v0.30.3 requires go >= 1.22.0 (running go 1.21.12)

Related to #60

